### PR TITLE
converting null to a collection now returns null

### DIFF
--- a/projects/data-model/source/java/org/alfresco/service/cmr/repository/datatype/TypeConverter.java
+++ b/projects/data-model/source/java/org/alfresco/service/cmr/repository/datatype/TypeConverter.java
@@ -359,12 +359,12 @@ public class TypeConverter
      */
     private final Collection<?> createCollection(Object value)
     {
-        Collection<?> coll;
+        Collection<?> coll = null;
         if (isMultiValued(value))
         {
             coll = (Collection<?>) value;
         }
-        else
+        else if (coll != null)
         {
             ArrayList<Object> list = new ArrayList<Object>(1);
             list.add(value);


### PR DESCRIPTION
When you convert null to a collection, you currently get an array list with a null entry.  

The common-sense result is null, or alternatively a zero-element collection.  I propose returning null.